### PR TITLE
Fix multi-directory clp file rewriting

### DIFF
--- a/webactions/clpage.cl
+++ b/webactions/clpage.cl
@@ -368,6 +368,9 @@ v1: add timeout to webaction-project."
 	       
 	       `(:clp "wa" "link"
 		      (("name" . ,dest)
+		       ;; added by cac 29jun16 -- pass to wa_link for
+		       ;; relative-path / webaction-destination fixup.
+		       ("filename" . ,filename)
 		       ,@(if* extra then 
 				 `(("extra" . ,extra))))
 		      nil))))

--- a/webactions/clpcode/wa.cl
+++ b/webactions/clpcode/wa.cl
@@ -37,7 +37,10 @@
 	 (let ((name (locate-action-path
 		      wa 
 		      (cdr (assoc "name" args :test #'equal))
-		      session)))
+		      session
+		      ;; pass through any filename from clp parser for relative
+		      ;; url fixup.  cac 29jun16
+		      :filename (cdr (assoc "filename" args :test #'equal)))))
 	   (html (:princ name))
 	   (let ((extra (cdr (assoc "extra" args :test #'equal))))
 	     (if* extra

--- a/webactions/test/siteb/project.cl
+++ b/webactions/test/siteb/project.cl
@@ -1,0 +1,6 @@
+(in-package :net.aserve.testwa)
+
+(webaction-project "siteb"
+		   :project-prefix "/siteb/"
+		   :destination (directory-namestring *load-pathname*)
+		   :map '(("pageb" "sub/file1.clp")))

--- a/webactions/test/siteb/sub/file1.clp
+++ b/webactions/test/siteb/sub/file1.clp
@@ -1,0 +1,5 @@
+<html>
+  <head><title>webactions subdirectory test</title></head>
+  <body><h1>webactions subdirectory test</h1>
+    <a href="file2.html">file2.html</a>
+</body></html>

--- a/webactions/test/siteb/sub/file2.html
+++ b/webactions/test/siteb/sub/file2.html
@@ -1,0 +1,7 @@
+<html>
+  <head><title>Webactions subdirectory test -- target file</title></head>
+  <body>
+    <h1>Webactions subdirectory test -- target file</h1>
+    If this file is reached by following the link inside file1.clp, then the bug
+    is fixed.
+</body></html>

--- a/webactions/test/t-webactions.cl
+++ b/webactions/test/t-webactions.cl
@@ -1,4 +1,4 @@
-;; -*- mode: common-lisp; package: net.aserve.test -*-
+;; -*- mode: common-lisp; package: net.aserve.testwa -*-
 ;;
 ;; t-webactions.cl
 ;;
@@ -64,6 +64,7 @@
       (unwind-protect 
 	  (flet ((do-tests ()
 		  (sitea-tests port)
+		  (siteb-tests port)
 		   ))
 	    (format t "~%~%===== test direct ~%~%")
 	    (do-tests)
@@ -294,6 +295,25 @@
   (html "{start_foo}")
   (emit-clp-entity req ent body)
   (html "{end_foo}"))
+
+;; Begin siteb (subdirectory) tests
+
+(defun siteb-tests (port)
+  (let ((prefix-local (format nil "http://localhost:~a" port)))
+    (load (concatenate 'string *test-dir* "siteb/project.cl"))
+
+    (multiple-value-bind (data retcode)
+	(x-do-http-request (format nil "~a/siteb/sub/file1.clp" prefix-local))
+      ;; Without bug fix, the rewritten line does not have "sub/".
+      (test "/sub/file2.html\">file2.html</a>" data
+	    :test #'(lambda (x y) (search x y))))
+    (multiple-value-bind (data retcode)
+	(x-do-http-request (format nil "~a/siteb/pageb" prefix-local))
+      ;; Without bug fix, the rewritten line does not have "sub/".
+      (test "/sub/file2.html\">file2.html</a>" data
+	    :test #'(lambda (x y) (search x y))))))
+
+;; End siteb (subdirectory) tests
 
 
 

--- a/webactions/webact.cl
+++ b/webactions/webact.cl
@@ -619,14 +619,15 @@ no map for webaction with default-actions ~s"
 		     then (return (cdr pp))))))))
 
 
-(defun locate-action-path (wa action-name websession)
+;; cac added &key filename for relative-pathname fixup.  29jun16
+(defun locate-action-path (wa action-name websession &key (filename nil))
   ;; return the full uri path for what action points to
   ;; if the action points to a page, otherwise return a pointer
   ;; to the action itself
   ;;** change -- always return a pointer to the action since
   ;;  that will allow the project to be redefined and not have
   ;;  the clp files reparsed.
-  (let* ((relative-path action-name)
+  (let* ((relative-path (relpath action-name wa filename))
 	 (prefix (webaction-project-prefix wa)))
     
     (relative-to-absolute-path 
@@ -640,6 +641,18 @@ no map for webaction with default-actions ~s"
 	       "~/")
 	else prefix)
      relative-path)))
+
+;; added by cac for relative pathname url rewrite fixup.  29jun16
+(defun relpath (action-name wa filename)
+  (if* filename
+     then (concatenate 'string
+	    (substitute #\/ #\\
+			(namestring (path-pathname
+				     (enough-namestring
+				      (merge-pathnames (pathname filename))
+				      (pathname (webaction-destination wa))))))
+	    action-name)
+     else action-name))
 
 
 (defun relative-to-absolute-path (prefix relative-path)


### PR DESCRIPTION
Problem being solved:
URLs that get rewritten by the clp file parser have been set to root at the
destination directory.
This means clp files in subdirectories that have relative url references are
having those references mis-written.

This commit:
This commit fixes the problem by keeping track of the pathname position of
the clp file being parsed relative to the webaction's destination-directory.

	* webactions/clpage.cl: Pass pathname of clp file being parsed to
	wa_link for relative-path fixup.

	* webactions/clpcode/wa.cl: Pass any pathname in the args to
	locate-action-path, which now has a (as unyet undocumented) new
	:filename keyword arg.

	* webactions/test/siteb/: Test for this change.

	* webactions/test/t-webactions.cl: Add new test.

	* webactions/webact.cl: Give locate-action-path a :filename
	keyword argument, and set the relative path based on the
	filename's position relative to the webaction's
	destination-directory.