### PR TITLE
Update an ignore-if-unused declaration to ignorable.

### DIFF
--- a/main.cl
+++ b/main.cl
@@ -794,7 +794,7 @@ Problems with protocol may occur." (ef-name ef)))))
 	   #+(and allegro (version>= 6 0 pre-final 1))
 	   (,g-external-format (find-external-format ,external-format))
 	   )
-       (declare (ignore-if-unused ,g-req ,g-ent ,g-external-format))
+       (declare (ignorable ,g-req ,g-ent ,g-external-format))
         
        (compute-response-stream ,g-req ,g-ent)
        (if* (entity-headers ,g-ent)


### PR DESCRIPTION
Improves portability, as "ignorable" is CL standard, and already used
in every other part of the code. The semantics of ignore-if-unused and
ignorable are the same, according to
http://franz.com/support/documentation/current/doc/environments.htm.