### PR TITLE
Provide an :initial-element to the *HEADER-INDEX-SRESOURCE* array

### DIFF
--- a/headers.cl
+++ b/headers.cl
@@ -277,7 +277,7 @@
 		 (if* size
 		    then (error "size can't be specifed for header index"))
 		 
-		 (make-array *header-count*))
+		 (make-array *header-count* :initial-element nil))
      :init #'(lambda (sresource buffer)
 	       (declare (ignore sresource))
 	       (dotimes (i (length buffer))


### PR DESCRIPTION
Without :initial-element, Allegro CL initializes to NIL, but Clozure
CL (and others) use 0. The CL spec says that the consequences of reading
from an uninitialized array index are undefined:

    If initial-element is not supplied, the consequences of later
    reading an uninitialized element of new-array are undefined unless
    either initial-contents is supplied or displaced-to is non-nil.