### PR TITLE
Add support for portability and inclusion in Quicklisp, clean up style-warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.fasl
+*.dx64fsl
 .git-branch-name
 /build.tmp
 /test.out

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ value of excl:\*current-case-mode\*
 
 ### Loading from source on Allegro CL
 
-    load in the file load.cl 
+load in the file load.cl 
 
     user(1):  :ld <path-to-aserve>/load.cl
 
@@ -113,7 +113,7 @@ the examples file too.
 
 ### Loading into a non-Allegro CL
 
-   CL-USER> (ql:quickload :zaserve)
+    CL-USER> (ql:quickload :zaserve)
 
 This will not load the example files. 
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,44 @@ network programming in Allegro Common Lisp.  AllegroServe was written
 according to a certain coding standard to demonstrate how Lisp programs 
 are more readable if certain macros and special forms are avoided.
 
+
+A Note on Portability
+---------------------
+
+See the Installation section below for information on running
+AllegroServe on CL implementations other than Allegro CL. 
+
+Although AllegroServe was originally written with portability (to
+other CL implementations) as "neither a goal nor a non-goal"
+(according to John Foderaro), it is a testament to the cleanliness of
+the AllegroServe codebase, as well as the flexibility of Common Lisp,
+and the power of the CL ANSI standard, that some ports of AllegroServe
+have in fact been accomplished over the years.
+
+The most recent one attempts to keep the official AllegroServe code
+unmodified, and uses a compatibility layer called
+["ZACL"](https://gitlab.common-lisp.net/zbeane/zacl), available in
+Quicklisp as `:zacl`.
+
+With this said, please do keep in mind that Allegro CL is
+AllegroServe's native platform, and as such it will always work and
+perform best on Allegro CL. So if you have mission-critical or
+performance-critical applications, it will be to your advantage to
+invest in Allegro CL for developing and running your applications.
+
+And probably most important of all for your mission-critical
+applications, running AllegroServe natively on a supported
+installation of Allegro CL comes backed with the dedicated,
+unparalleled support of the world-class Franz Inc. staff of engineers.
+
+
 Platforms
 ---------
 
 AllegroServe works on all versions of Allegro Common Lisp since 6.0.
+
+It can also run to some extent on other CL implementations (see "A
+Note on Portability" above and "Installation" below).
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ AllegroServe works on all versions of Allegro Common Lisp since 6.0.
 Dependencies
 ------------
 
-There are no dependences for AllegroServe.  In order to run the
-allegroserve test suite you'll need to have the tester module
+There are no dependences for AllegroServe on Allegro CL.  In order to
+run the allegroserve test suite you'll need to have the tester module
 (available at <https://github.com/franzinc>) loaded.
 
 Installation
@@ -96,12 +96,30 @@ This should work in a lisp running in a :case-insensitive-upper or
 testing in a :case-sensitive-lower lisp.  The current case mode is the
 value of excl:\*current-case-mode\* 
 
-### load in the file load.cl 
+
+### Loading precompiled, installed version into Allegro CL
+
+    user(1): (require :aserve)
+
+
+### Loading from source on Allegro CL
+
+    load in the file load.cl 
 
     user(1):  :ld <path-to-aserve>/load.cl
 
 it will compile and and load all of AllegroServe, and it will load in
 the examples file too.
+
+### Loading into a non-Allegro CL
+
+   CL-USER> (ql:quickload :zaserve)
+
+This will not load the example files. 
+
+Note: For information on compatibility with non-Allegro CLs, please
+      refer [here](https://gitlab.common-lisp.net/zbeane/zacl).
+
 
 ### start the server
 

--- a/aserve.asd
+++ b/aserve.asd
@@ -8,7 +8,10 @@
   (defclass asdf::cl-file (asdf:cl-source-file) ())
   (defmethod asdf:source-file-type ((c asdf::cl-file) (s asdf:module)) "cl"))
 
+#-(or allegro ccl sbcl) (error "This version of aserve is not yet supported on ~a~%" (lisp-implementation-type))
+
 (asdf:defsystem :aserve
+  :depends-on (#+(or ccl sbcl) :zacl)
   :components
   ;; this list is in cl/src/sys/make.cl as well... keep in sync
   ((:module "htmlgen" :components ((:cl-file "htmlgen")

--- a/aserve.asd
+++ b/aserve.asd
@@ -8,8 +8,6 @@
   (defclass asdf::cl-file (asdf:cl-source-file) ())
   (defmethod asdf:source-file-type ((c asdf::cl-file) (s asdf:module)) "cl"))
 
-(asdf:disable-output-translations)
-
 (asdf:defsystem :aserve
   :components
   ;; this list is in cl/src/sys/make.cl as well... keep in sync

--- a/authorize.cl
+++ b/authorize.cl
@@ -15,7 +15,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (defclass authorizer ()
   ;; denotes information on authorizing access to an entity

--- a/cgi.cl
+++ b/cgi.cl
@@ -16,7 +16,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (defun run-cgi-program (req ent program
 			&key
@@ -174,7 +174,6 @@
 			   :wait nil
 			   :environment envs
 			   :show-window :hide)
-      (declare (ignore ignore-this))
 	    
       (unwind-protect
 	  ; first send the body to the script

--- a/chunker.cl
+++ b/chunker.cl
@@ -155,15 +155,19 @@
   nil
   )
 
+#+zlib-deflate
 (defmethod set-trailers ((p deflate-stream) trailers)
   (set-trailers (deflate-target-stream p) trailers))
 
+#+zlib-deflate
 (defmethod can-set-trailers-p ((p deflate-stream))
   (can-set-trailers-p (deflate-target-stream p)))
 
+#+zlib-deflate
 (defmethod excl::socket-bytes-written ((stream deflate-stream) &optional set)
   (excl::socket-bytes-written (deflate-target-stream stream) set))
 
+#+zlib-deflate
 (defmethod excl::socket-bytes-read ((stream deflate-stream) &optional set)
   (excl::socket-bytes-read (deflate-target-stream stream) set))
 

--- a/chunker.cl
+++ b/chunker.cl
@@ -13,7 +13,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 ; stream that reads the input and chunks the data to the output
 

--- a/client.cl
+++ b/client.cl
@@ -738,8 +738,8 @@
   ;; We cannot do this at compile time because :ssl isn't loaded when
   ;; aserve is compiled.  In fact, the test is written so that autoloading
   ;; of :ssl is not triggered.
-  #-(version>= 10 1) nil
-  #+(version>= 10 1)
+  #-(and (not zacl) (version>= 10 1)) nil
+  #+(and (not zacl) (version>= 10 1))
   (let ((sym (find-symbol (symbol-name :*ssl-features*)
 			  (find-package :acl-socket))))
     (when (and sym

--- a/client.cl
+++ b/client.cl
@@ -20,7 +20,7 @@
 
 (in-package :net.aserve.client)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (net.aserve::check-smp-consistency)
 
@@ -1175,10 +1175,6 @@
   ;   we return nil for the socket as the value of proxy
   ;;  as the proxy so its value won't change
   ;;  
-  
-  (declare (ignorable certificate key certificate-password
-                      ca-file ca-directory crl-file crl-check
-                      verify max-depth ssl-method))
   
   (let* ((uri (net.uri:parse-uri url))
          (host (net.uri:uri-host uri))

--- a/decode.cl
+++ b/decode.cl
@@ -14,7 +14,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 ;---------------- urlencoding ----------------
 ; there are two similar yet distinct encodings for character strings

--- a/decode.cl
+++ b/decode.cl
@@ -577,11 +577,11 @@
 ;;
 
 
-#+allegro
+#+(and allegro (not zacl))
 (defun base64-decode (string)
   (excl:base64-string-to-string string))
 
-#-allegro
+#-(and allegro (not zacl))
 (defun base64-decode (string)
   ;;
   ;; given a base64 string, return it decoded.
@@ -623,11 +623,11 @@
     res))
 
 
-#+allegro
+#+(and allegro (not zacl))
 (defun base64-encode (str)
   (excl:string-to-base64-string str))
 
-#-allegro
+#-(and allegro (not zacl))
 (defun base64-encode (str)
   ;;
   ;; take the given string and encode as a base64 string

--- a/decode.cl
+++ b/decode.cl
@@ -577,11 +577,11 @@
 ;;
 
 
-#+(and allegro (not zacl))
+#+allegro
 (defun base64-decode (string)
   (excl:base64-string-to-string string))
 
-#-(and allegro (not zacl))
+#-allegro
 (defun base64-decode (string)
   ;;
   ;; given a base64 string, return it decoded.
@@ -623,11 +623,11 @@
     res))
 
 
-#+(and allegro (not zacl))
+#+allegro
 (defun base64-encode (str)
   (excl:string-to-base64-string str))
 
-#-(and allegro (not zacl))
+#-allegro
 (defun base64-encode (str)
   ;;
   ;; take the given string and encode as a base64 string

--- a/examples/examples.cl
+++ b/examples/examples.cl
@@ -75,7 +75,7 @@
 			 (:b "bar2") ")"
 			 :br
 			 ((:a :href "local-secret") "Test source based authorization") " This will only work if you can use "
-			 "http:://localhost ... to reach this page" :
+			 "http://localhost ... to reach this page" 
 			 :br
 			 ((:a :href "local-secret-auth") 
 			  "Like the preceding but uses authorizer objects")

--- a/headers.cl
+++ b/headers.cl
@@ -172,7 +172,7 @@
     
       (let ((header-byte-array (make-array total-length
 					   :element-type '(unsigned-byte 8)))
-	    (header-lookup-array (make-array (1+ max-length))))
+	    (header-lookup-array (make-array (1+ max-length) :initial-element nil)))
       
 	(let ((hba -1)
 	      (header-number -1)

--- a/htmlgen/htmlgen.cl
+++ b/htmlgen/htmlgen.cl
@@ -32,7 +32,7 @@
 
 (in-package :net.html.generator)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 ;; html generation
 

--- a/log.cl
+++ b/log.cl
@@ -15,7 +15,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (defun log1 (category level message &key (logger *logger*))
   (log1* logger category level message))

--- a/macs.cl
+++ b/macs.cl
@@ -21,7 +21,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 ;; add features based on the capabilities of the host lisp
 #+(version>= 6 1) (pushnew :io-timeout *features*) ; support i/o timeouts

--- a/main.cl
+++ b/main.cl
@@ -1688,32 +1688,33 @@ by keyword symbols and not by strings"
 	     ;; 8.1.
 	     #+(version>= 8 1)
 	     ((member :zoom-on-error *debug-current* :test #'eq)
-	      (tagbody out
-		(handler-bind
-		    ((error
-		      (lambda (cond)
-			(if* (connection-reset-error cond)
-			   then (go out) ;; don't print these errors,
-			   else (logmess 
-				 (format nil "~agot error ~a~%" 
-					 (if* *worker-request*
-					    then (format 
-						  nil 
-						  "while processing command ~s~%"
-						  (request-raw-request 
-						   *worker-request*))
-					    else "")
-					 cond))
-				(top-level.debug:zoom
-				 (or (vhost-error-stream
-				      (wserver-default-vhost
-				       *wserver*))
-				     *initial-terminal-io*))
-				(if* (not (member :notrap *debug-current*))
+	      (tagbody
+		 (handler-bind
+		     ((error
+		       (lambda (cond)
+			 (if* (connection-reset-error cond)
+			      then (go out) ;; don't print these errors,
+			      else (logmess 
+				    (format nil "~agot error ~a~%" 
+					    (if* *worker-request*
+						 then (format 
+						       nil 
+						       "while processing command ~s~%"
+						       (request-raw-request 
+							*worker-request*))
+						 else "")
+					    cond))
+			      (top-level.debug:zoom
+			       (or (vhost-error-stream
+				    (wserver-default-vhost
+				     *wserver*))
+				   *initial-terminal-io*))
+			      (if* (not (member :notrap *debug-current*))
 				   then ; after the zoom ignore the error
-					(go out))
-				))))
-		  (process-connection sock))))
+				   (go out))
+			      ))))
+		   (process-connection sock))
+	       out))
 	     ((not (member :notrap *debug-current* :test #'eq))
 	      (handler-case (process-connection sock)
 		(error (cond)

--- a/main.cl
+++ b/main.cl
@@ -1111,7 +1111,7 @@ by keyword symbols and not by strings"
     :initform (get-universal-time)	  ; when we're responding
     :accessor request-reply-date)
    
-   (reply-microtime	  ; microsecond time when reply done
+   (reply-microtime	 ; microsecond time when reply done
     :initform 0
     :accessor request-reply-microtime)
    

--- a/main.cl
+++ b/main.cl
@@ -1103,7 +1103,6 @@ by keyword symbols and not by strings"
     :initform 0
     :accessor request-request-date)
    
-   #-zacl
    (request-microtime	       ; microsecond time when request came in
     :initform 0
     :accessor request-request-microtime)
@@ -1112,7 +1111,6 @@ by keyword symbols and not by strings"
     :initform (get-universal-time)	  ; when we're responding
     :accessor request-reply-date)
    
-   #-zacl
    (reply-microtime		    ; microsecond time when reply done
     :initform 0
     :accessor request-reply-microtime)
@@ -1943,11 +1941,11 @@ by keyword symbols and not by strings"
 		  (setq *worker-request* req) 
 		  
 		  (setf (request-request-date req) (get-universal-time))
-                  #-zacl (setf (request-request-microtime req) (get-micro-real-time))
+                  (setf (request-request-microtime req) (get-micro-real-time))
 
 		  (handle-request req)
 		  (setf (request-reply-date req) (get-universal-time))
-                  #-zacl (setf (request-reply-microtime req) (get-micro-real-time))
+                  (setf (request-reply-microtime req) (get-micro-real-time))
 		  
 		  (force-output-noblock (request-socket req))
 
@@ -3537,7 +3535,7 @@ in get-multipart-sequence"))
 		       then (values (car parts) port))))))
 
 ;------
-#-zacl
+
 (defun get-micro-real-time ()
   (multiple-value-bind (secs usecs) (excl::acl-internal-real-time)
     (+ (* 1000000 (- secs excl::base-for-internal-real-time))

--- a/main.cl
+++ b/main.cl
@@ -1103,7 +1103,8 @@ by keyword symbols and not by strings"
     :initform 0
     :accessor request-request-date)
    
-   (request-microtime      ; microsecond time when request came in
+   #-zacl
+   (request-microtime	       ; microsecond time when request came in
     :initform 0
     :accessor request-request-microtime)
    
@@ -1111,7 +1112,8 @@ by keyword symbols and not by strings"
     :initform (get-universal-time)	  ; when we're responding
     :accessor request-reply-date)
    
-   (reply-microtime	 ; microsecond time when reply done
+   #-zacl
+   (reply-microtime		    ; microsecond time when reply done
     :initform 0
     :accessor request-reply-microtime)
    
@@ -1941,11 +1943,11 @@ by keyword symbols and not by strings"
 		  (setq *worker-request* req) 
 		  
 		  (setf (request-request-date req) (get-universal-time))
-                  (setf (request-request-microtime req) (get-micro-real-time))
+                  #-zacl (setf (request-request-microtime req) (get-micro-real-time))
 
 		  (handle-request req)
 		  (setf (request-reply-date req) (get-universal-time))
-                  (setf (request-reply-microtime req) (get-micro-real-time))
+                  #-zacl (setf (request-reply-microtime req) (get-micro-real-time))
 		  
 		  (force-output-noblock (request-socket req))
 
@@ -3535,10 +3537,11 @@ in get-multipart-sequence"))
 		       then (values (car parts) port))))))
 
 ;------
+#-zacl
 (defun get-micro-real-time ()
   (multiple-value-bind (secs usecs) (excl::acl-internal-real-time)
     (+ (* 1000000 (- secs excl::base-for-internal-real-time))
-	 usecs)))
+       usecs)))
       
 ;-------
 

--- a/main.cl
+++ b/main.cl
@@ -1103,7 +1103,7 @@ by keyword symbols and not by strings"
     :initform 0
     :accessor request-request-date)
    
-   (request-microtime	       ; microsecond time when request came in
+   (request-microtime       ; microsecond time when request came in
     :initform 0
     :accessor request-request-microtime)
    
@@ -1111,7 +1111,7 @@ by keyword symbols and not by strings"
     :initform (get-universal-time)	  ; when we're responding
     :accessor request-reply-date)
    
-   (reply-microtime		    ; microsecond time when reply done
+   (reply-microtime	    ; microsecond time when reply done
     :initform 0
     :accessor request-reply-microtime)
    

--- a/main.cl
+++ b/main.cl
@@ -16,14 +16,14 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 #+ignore
 (check-smp-consistency)
 
 (defparameter *aserve-version* '(1 3 65))
 
-(eval-when (eval load)
+(eval-when (:execute :load-toplevel)
     (require :sock)
     (require :process)
     #+(version>= 6) (require :acldns) ; not strictly required but this is preferred
@@ -850,7 +850,7 @@ Problems with protocol may occur." (ef-name ef)))))
        
 
 
-(eval-when (compile load eval)
+(eval-when (:compile-toplevel :load-toplevel :execute)
   ;; these are the common headers and are stored in slots in 
   ;; the objects
   ;; the list consists of  ("name" . name)

--- a/main.cl
+++ b/main.cl
@@ -1103,7 +1103,7 @@ by keyword symbols and not by strings"
     :initform 0
     :accessor request-request-date)
    
-   (request-microtime       ; microsecond time when request came in
+   (request-microtime      ; microsecond time when request came in
     :initform 0
     :accessor request-request-microtime)
    
@@ -1111,7 +1111,7 @@ by keyword symbols and not by strings"
     :initform (get-universal-time)	  ; when we're responding
     :accessor request-reply-date)
    
-   (reply-microtime	    ; microsecond time when reply done
+   (reply-microtime	  ; microsecond time when reply done
     :initform 0
     :accessor request-reply-microtime)
    

--- a/packages.cl
+++ b/packages.cl
@@ -4,7 +4,7 @@
 ;;
 ;; See the file LICENSE for the full license governing this code.
 
-#+(version= 10 1)
+#+(and (not zacl) (version= 10 1))
 (sys:defpatch "aserve" 15
   "v15: 1.3.65: device-read fix for truncated-stream; remove dup auth header;
 v14: 1.3.64: proxing https through a tunnel
@@ -24,7 +24,7 @@ v1: 1.3.49: speed up read-sock-line."
   :type :system
   :post-loadable t)
 
-#+(version= 10 0)
+#+(and (not zacl) (version= 10 0))
 (sys:defpatch "aserve" 23
   "v23: 1.3.64: proxing https through a tunnel 
 v22: 1.3.63: do request timing in microseconds
@@ -52,7 +52,7 @@ v1: 1.3.36: cosmetic: bump version #; code same as 10.0 initial release."
   :type :system
   :post-loadable t)
 
-#+(version= 9 0)
+#+(and (not zacl) (version= 9 0))
 (sys:defpatch "aserve" 23
   "v23: 1.3.62: proxing https through a tunnel
 v22: 1.3.52: optimize compilation for speed;
@@ -312,7 +312,7 @@ without compression.  Original error loading deflate was:~%~a~%~:@>" c)
 
 ;; These functions must be undefined in case new aserve is loaded on
 ;;   top of older aserve in 8.1. [bug23328] 
-#+(version= 8 1)
+#+(and (not zacl) (version= 8 1))
 (eval-when (compile load eval)
   (fmakunbound 'net.aserve::logmess)
   (fmakunbound 'net.aserve::logmess-stream)

--- a/packages.cl
+++ b/packages.cl
@@ -93,9 +93,9 @@ v1: 1.3.16: fix freeing freed buffer."
 ;
 (in-package :user)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
-(eval-when (compile load eval)
+(eval-when (:compile-toplevel :load-toplevel :execute)
   (require :osi)
   (require :autozoom)
   (require :uri)
@@ -103,7 +103,7 @@ v1: 1.3.16: fix freeing freed buffer."
   (require :streamc)
   (require :inflate))
 
-(eval-when (compile load eval)
+(eval-when (:compile-toplevel :load-toplevel :execute)
   (defvar sys::*user-warned-about-deflate* nil)
   (handler-case (require :deflate)
     (error (c)
@@ -313,7 +313,7 @@ without compression.  Original error loading deflate was:~%~a~%~:@>" c)
 ;; These functions must be undefined in case new aserve is loaded on
 ;;   top of older aserve in 8.1. [bug23328] 
 #+(and (not zacl) (version= 8 1))
-(eval-when (compile load eval)
+(eval-when (:compile-toplevel :load-toplevel :execute)
   (fmakunbound 'net.aserve::logmess)
   (fmakunbound 'net.aserve::logmess-stream)
   (fmakunbound 'net.aserve.client::read-client-response-headers)

--- a/parse.cl
+++ b/parse.cl
@@ -18,7 +18,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (check-smp-consistency)
 

--- a/proxy.cl
+++ b/proxy.cl
@@ -15,7 +15,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (check-smp-consistency)
 
@@ -50,7 +50,7 @@
    (nil `(si::without-scheduling ,s ,@body)))) ;; in a #-smp block
 
 ; denotes a request from the browser
-(defconstant *browser-level* 100) ;
+(defconstant +browser-level+ 100) ;
 
 (defparameter *extra-lifetime-factor* 1.1)
 
@@ -432,7 +432,7 @@
 		      (handle-request req)
 		 else ; must really proxy
 		      (check-cache-then-proxy-request 
-		       req ent t *browser-level*))))))
+		       req ent t +browser-level+))))))
 
 
   
@@ -443,7 +443,7 @@
 		     
 
 (defun proxy-request (req ent &key pcache-ent (respond t) 
-				   (level *browser-level*))
+				   (level +browser-level+))
   ;; a request has come in with an http scheme given in uri
   ;; and a machine name which isn't ours.
   ;; 
@@ -1296,7 +1296,7 @@ cached connection = ~s~%" cond cached-connection))
        then (error "There is no memory cache to size"))
     
     ; store it in blocks
-    (setf (pcache-size pcache) (truncate size *header-block-size*))
+    (setf (pcache-size pcache) (truncate size +header-block-size+))
     
     (setf (pcache-high-water pcache) (truncate (* .90 (pcache-size pcache))))
     (setf (pcache-low-water pcache) (truncate (* .80 (pcache-size pcache))))))
@@ -1311,7 +1311,7 @@ cached connection = ~s~%" cond cached-connection))
 	      (if* (not (probe-file name))
 		 then (setq filename name) 
 		      (return)))))
-  (let* ((blocks (truncate size *header-block-size*))
+  (let* ((blocks (truncate size +header-block-size+))
 	 (pcache-disk (make-pcache-disk
 		       :filename filename
 		       :queueobj (make-and-init-queueobj)
@@ -1429,7 +1429,7 @@ cached connection = ~s~%" cond cached-connection))
 		  (:td (:princ (queueobj-blocks (pcache-queueobj pcache)))
 		       " ("
 		       (:princ (* (queueobj-blocks (pcache-queueobj pcache)) 
-				  *header-block-size*))
+				  +header-block-size+))
 		
 		       " bytes)")))
 	    
@@ -1439,7 +1439,7 @@ cached connection = ~s~%" cond cached-connection))
 	     (:td (:princ dead-bytes))
 	     (:td (:princ dead-blocks)
 		  " ("
-		  (:princ (* dead-blocks *header-block-size*)) " bytes)"
+		  (:princ (* dead-blocks +header-block-size+)) " bytes)"
 		  ))
 	    )
 	   :br
@@ -1641,7 +1641,7 @@ cached connection = ~s~%" cond cached-connection))
 	      ; result looks good
 	      (progn
 		(dlogmess (format nil "not in cache, proxy it level ~d" level))
-		(if* (eql *browser-level* level)
+		(if* (eql +browser-level+ level)
 		   then (incf (pcache-r-miss pcache))
 			(log-proxy rendered-uri level :mi nil)
 		   else (incf (pcache-r-cache-fill pcache))
@@ -1666,7 +1666,7 @@ cached connection = ~s~%" cond cached-connection))
 			    ; of if this wasn't a fast hit and thus there
 			    ; is new data to cache
 			    (if* (and (pcache-entry-cached-hook pcache)
-				      (or (eql level *browser-level*)
+				      (or (eql level +browser-level+)
 					  (not (member response '(:fh :fv :sh)
 						       :test #'eq))))
 			       then ; we want to do link scanning of this
@@ -2549,7 +2549,7 @@ cached connection = ~s~%" cond cached-connection))
 	 (pcache-disk (pcache-ent-pcache-disk pcache-ent))
 	 (stream (pcache-disk-stream pcache-disk))
 	 (bytes (+ (pcache-ent-data-length pcache-ent)
-		   *header-block-size*))
+		   +header-block-size+))
 	 (res))
     (dlogmess (format nil "retrieve ~s in blocks ~s~%"
 		      (pcache-ent-key pcache-ent)
@@ -2560,12 +2560,12 @@ cached connection = ~s~%" cond cached-connection))
       ;; get a lock so we're the only thread doing operations
       ;; on the stream to the cache
       (dolist (ent block-list)
-	(file-position stream (* (car ent) *header-block-size*))
+	(file-position stream (* (car ent) +header-block-size+))
 	(dotimes (i (1+ (- (cdr ent) (car ent))))
 	  (let ((buff (get-header-block)))
-	    (read-sequence buff stream :end (min *header-block-size*
+	    (read-sequence buff stream :end (min +header-block-size+
 						 bytes))
-	    (decf bytes *header-block-size*)
+	    (decf bytes +header-block-size+)
 	    (push buff res))))
       (setf (pcache-ent-data pcache-ent) (nreverse res))
       
@@ -2686,23 +2686,23 @@ cached connection = ~s~%" cond cached-connection))
   ;;
   (let ((buffers (pcache-ent-data pcache-ent))
 	(stream (pcache-disk-stream pcache-disk))
-	(bytes (+  *header-block-size*  ; for header block
+	(bytes (+  +header-block-size+  ; for header block
 		   (pcache-ent-data-length pcache-ent))))
     (dlogmess (format nil "writing ~d buffers to list ~d~%" 
 		     (length buffers)
 		     list-of-blocks))
     (dolist (ent list-of-blocks)
       ; prepare to write
-      (file-position stream (* (car ent) *header-block-size*))
+      (file-position stream (* (car ent) +header-block-size+))
       
       (dotimes (i (1+ (- (cdr ent) (car ent))))
 	(if* (null buffers)
 	   then (error "ran out of buffers before blocks"))
-	(let ((length (min *header-block-size* bytes)))
+	(let ((length (min +header-block-size+ bytes)))
 	  (if* (> length 0)
 	     then (write-sequence (car buffers) stream :end length)))
 	(pop buffers)
-	(decf bytes *header-block-size*)))))
+	(decf bytes +header-block-size+)))))
     
 
 				      

--- a/publish.cl
+++ b/publish.cl
@@ -823,9 +823,9 @@
     (if* preload
        then ; keep the content in core for fast display
 	    (with-open-file (p file
-			     #-(and allegro (version>= 6))
+			     #-(and (not zacl) allegro (version>= 6))
 			     :element-type
-			     #-(and allegro (version>= 6))
+			     #-(and (not zacl) allegro (version>= 6))
 			     '(unsigned-byte 8))
 	      (let ((size (excl::filesys-size (stream-input-fn p)))
 		    (lastmod (excl::filesys-write-date (stream-input-fn p)))
@@ -1567,9 +1567,9 @@
     (if* (null (errorset 
 		(setq p (open filename
 			      :direction :input
-			      #-(and allegro (version>= 6))
+			      #-(and (not zacl) allegro (version>= 6))
 			      :element-type
-			      #-(and allegro (version>= 6))
+			      #-(and (not zacl) allegro (version>= 6))
 			      '(unsigned-byte 8)))))
        then ; file not readable
 		      

--- a/publish.cl
+++ b/publish.cl
@@ -14,7 +14,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (defclass entity ()
   ;; an object to be published
@@ -1540,7 +1540,7 @@
 
 ; this is stack allocated so don't make it too big
 (defparameter *send-buffer-lock* (mp:make-process-lock))
-(defconstant  *send-buffer-size* #.(* 16 1024))
+(defconstant  +send-buffer-size+ #.(* 16 1024))
 
 (defvar *send-buffers* nil)
 
@@ -1549,7 +1549,7 @@
     (let ((buff (pop *send-buffers*)))
       (if* buff
 	 thenret
-	 else (make-array *send-buffer-size* :element-type '(unsigned-byte 8))))))
+	 else (make-array +send-buffer-size+ :element-type '(unsigned-byte 8))))))
 
 (defun free-send-buffer (buffer)
   (mp:with-process-lock (*send-buffer-lock*)

--- a/queue.cl
+++ b/queue.cl
@@ -3,7 +3,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 #+(version= 8 2)
 (eval-when (:compile-toplevel :load-toplevel :execute)

--- a/require-original-aserve.cl
+++ b/require-original-aserve.cl
@@ -1,0 +1,5 @@
+(in-package :cl-user)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (require :aserve))
+

--- a/zaserve.asd
+++ b/zaserve.asd
@@ -4,9 +4,6 @@
 (defvar *loadswitch* :compile-if-needed)
 (defparameter *aserve-root* (directory-namestring *load-pathname*))
 
-(unless (find-class 'asdf::cl-file nil)
-  (defclass asdf::cl-file (asdf:cl-source-file) ())
-  (defmethod asdf:source-file-type ((c asdf::cl-file) (s asdf:module)) "cl"))
 
 #+allegro
 (asdf:defsystem :zaserve
@@ -17,6 +14,8 @@
     :default-component-class cl-source-file.cl
     :components ((:cl-file "require-original-aserve")))
 
+
+#-allegro
 (defun check-platform-compatibilty ()
   (unless (or (member :ccl *features*)
 	      (member :sbcl *features*))
@@ -33,41 +32,46 @@ layer (instead of this old acl-compat), is not currently supported on
 "
 	   (lisp-implementation-type) (lisp-implementation-type))))
 
-#-allegro
-(asdf:defsystem :zaserve
-  :depends-on (:zacl)
-  :version "1.3.65"
-  :name "AllegroServe"
-  :author "John K. Foderaro"
-  :licence "LLGPL"
-  :components
-  ;; this list is in load.cl as well... keep in sync
-  ((:module "htmlgen" :components ((:cl-file "htmlgen")
-                                   (:static-file "ChangeLog")))
-   (:cl-file "packages")
-   (:cl-file "macs")
-   (:cl-file "queue")
-   (:cl-file "main")
-   (:cl-file "headers")
-   (:cl-file "parse")
-   (:cl-file "decode")
-   (:cl-file "publish")
-   (:cl-file "authorize")
-   (:cl-file "log" )
-   (:cl-file "client")
-   (:cl-file "proxy")
-   (:cl-file "cgi")
-   (:cl-file "chunker")
-   #+include-playback (:cl-file "playback")
+#-(or zacl allegro)
+(defpackage :zacl-reader (:export #:cl-file))
 
-   (:static-file "README.md")
-   (:static-file "ChangeLog")
-   (:static-file "license-lgpl.txt")
-   (:static-file "LICENSE")
-   (:static-file "load"))
-  :perform (asdf:load-op :before (op zaserve)
-			 (check-platform-compatibilty))
-  :serial t)
+#-allegro
+(asdf:defsystem
+ :zaserve
+ :depends-on (:zacl)
+ :defsystem-depends-on (:zacl)
+ :version "1.3.65"
+ :name "AllegroServe"
+ :author "John K. Foderaro"
+ :licence "LLGPL"
+ :components
+ ;; this list is in load.cl as well... keep in sync
+ ((:module "htmlgen" :components ((zacl-reader:cl-file "htmlgen")
+                                  (:static-file "ChangeLog")))
+  (zacl-reader:cl-file "packages")
+  (zacl-reader:cl-file "macs")
+  (zacl-reader:cl-file "queue")
+  (zacl-reader:cl-file "main")
+  (zacl-reader:cl-file "headers")
+  (zacl-reader:cl-file "parse")
+  (zacl-reader:cl-file "decode")
+  (zacl-reader:cl-file "publish")
+  (zacl-reader:cl-file "authorize")
+  (zacl-reader:cl-file "log" )
+  (zacl-reader:cl-file "client")
+  (zacl-reader:cl-file "proxy")
+  (zacl-reader:cl-file "cgi")
+  (zacl-reader:cl-file "chunker")
+  #+include-playback (zacl-reader:cl-file "playback")
+
+  (:static-file "README.md")
+  (:static-file "ChangeLog")
+  (:static-file "license-lgpl.txt")
+  (:static-file "LICENSE")
+  (:static-file "load"))
+ :perform (asdf:load-op :before (op zaserve)
+			(check-platform-compatibilty))
+ :serial t)
 
 
 

--- a/zaserve.asd
+++ b/zaserve.asd
@@ -8,6 +8,15 @@
   (defclass asdf::cl-file (asdf:cl-source-file) ())
   (defmethod asdf:source-file-type ((c asdf::cl-file) (s asdf:module)) "cl"))
 
+#+allegro
+(asdf:defsystem :zaserve
+    :name "AllegroServe (portable)"
+    :author "John K. Foderaro"
+    :version "1.3.65"
+    :licence "LLGPL"
+    :default-component-class cl-source-file.cl
+    :components ((:cl-file "require-original-aserve")))
+
 (defun check-platform-compatibilty ()
   (unless (or (member :ccl *features*)
 	      (member :sbcl *features*))
@@ -56,16 +65,9 @@ layer (instead of this old acl-compat), is not currently supported on
    (:static-file "license-lgpl.txt")
    (:static-file "LICENSE")
    (:static-file "load"))
-  :perform (asdf:load-op :before (op :zaserve)
+  :perform (asdf:load-op :before (op zaserve)
 			 (check-platform-compatibilty))
   :serial t)
 
 
-#+allegro
-(asdf:defsystem :zaserve
-    :name "AllegroServe (portable)"
-    :author "John K. Foderaro"
-    :version "1.3.65"
-    :licence "LLGPL"
-    :default-component-class cl-source-file.cl
-    :components ((:cl-file "require-original-aserve")))
+

--- a/zaserve.asd
+++ b/zaserve.asd
@@ -56,7 +56,7 @@ layer (instead of this old acl-compat), is not currently supported on
    (:static-file "license-lgpl.txt")
    (:static-file "LICENSE")
    (:static-file "load"))
-  :perform (asdf:load-op :before (op paserve)
+  :perform (asdf:load-op :before (op :zaserve)
 			 (check-platform-compatibilty))
   :serial t)
 

--- a/zaserve.asd
+++ b/zaserve.asd
@@ -60,5 +60,12 @@ layer (instead of this old acl-compat), is not currently supported on
 			 (check-platform-compatibilty))
   :serial t)
 
- 
 
+#+allegro
+(defsystem zaserve
+    :name "AllegroServe (portable)"
+    :author "John K. Foderaro"
+    :version "1.3.65"
+    :licence "LLGPL"
+    :default-component-class cl-source-file.cl
+    :components ((:file "require-original-aserve")))

--- a/zaserve.asd
+++ b/zaserve.asd
@@ -62,10 +62,10 @@ layer (instead of this old acl-compat), is not currently supported on
 
 
 #+allegro
-(defsystem zaserve
+(asdf:defsystem :zaserve
     :name "AllegroServe (portable)"
     :author "John K. Foderaro"
     :version "1.3.65"
     :licence "LLGPL"
     :default-component-class cl-source-file.cl
-    :components ((:file "require-original-aserve")))
+    :components ((:cl-file "require-original-aserve")))

--- a/zaserve.asd
+++ b/zaserve.asd
@@ -8,12 +8,31 @@
   (defclass asdf::cl-file (asdf:cl-source-file) ())
   (defmethod asdf:source-file-type ((c asdf::cl-file) (s asdf:module)) "cl"))
 
-#-(or allegro ccl sbcl) (error "This version of aserve is not yet supported on ~a~%" (lisp-implementation-type))
+(defun check-platform-compatibilty ()
+  (unless (or (member :ccl *features*)
+	      (member :sbcl *features*))
+    (error "
 
-(asdf:defsystem :aserve
-  :depends-on (#+(or ccl sbcl) :zacl)
+SORRY:
+=====
+
+This version of AllegroServe, which uses the `zacl' compatibility
+layer (instead of this old acl-compat), is not currently supported on
+~a. Please consider contributing, or requesting, a port of zacl for ~a.
+
+
+"
+	   (lisp-implementation-type) (lisp-implementation-type))))
+
+#-allegro
+(asdf:defsystem :zaserve
+  :depends-on (:zacl)
+  :version "1.3.65"
+  :name "AllegroServe"
+  :author "John K. Foderaro"
+  :licence "LLGPL"
   :components
-  ;; this list is in cl/src/sys/make.cl as well... keep in sync
+  ;; this list is in load.cl as well... keep in sync
   ((:module "htmlgen" :components ((:cl-file "htmlgen")
                                    (:static-file "ChangeLog")))
    (:cl-file "packages")
@@ -30,13 +49,16 @@
    (:cl-file "proxy")
    (:cl-file "cgi")
    (:cl-file "chunker")
-   (:cl-file "playback")
+   #+include-playback (:cl-file "playback")
 
    (:static-file "README.md")
    (:static-file "ChangeLog")
    (:static-file "license-lgpl.txt")
    (:static-file "LICENSE")
    (:static-file "load"))
+  :perform (asdf:load-op :before (op paserve)
+			 (check-platform-compatibilty))
   :serial t)
 
  
+


### PR DESCRIPTION
This makes some substantial changes to `aserve.asd` (including renaming it, to avoid a name clash with pre-existing [legacy Portable Allegroserve](https://sourceforge.net/p/portableaserve/git/ci/master/tree/) which has been in Quicklisp for years). The ASDF system name here is now "zaserve."  This may be reverted back to "aserve" in the future, if and when the [legacy Portable Allegroserve](https://sourceforge.net/p/portableaserve/git/ci/master/tree/) agree to rename their thing to `paserve` and free up "aserve" for its original (and rightful) owner.

If the change in .asd system name is going to cause problems in the meantime, then we can probably do some things to mitigate that (i.e. continue to include a `aserve.asd` here, and just not have it be indexed by Quicklisp under that name).  I went ahead with the change for now though, because I'm not sure who would be loading aserve from source code on Allegro CL through ASDF -- there's the `load.cl` for loading it from source on Allegro CL.  And most "normal users" on Allegro CL would be loading it with `(require :aserve)`  (`README.md` has been updated to reflect that).


 