### PR TITLE
Changes in support of ANSI CL compliance

### DIFF
--- a/authorize.cl
+++ b/authorize.cl
@@ -15,7 +15,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (defclass authorizer ()
   ;; denotes information on authorizing access to an entity

--- a/cgi.cl
+++ b/cgi.cl
@@ -16,7 +16,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (defun run-cgi-program (req ent program
 			&key
@@ -174,7 +174,6 @@
 			   :wait nil
 			   :environment envs
 			   :show-window :hide)
-      (declare (ignore ignore-this))
 	    
       (unwind-protect
 	  ; first send the body to the script

--- a/chunker.cl
+++ b/chunker.cl
@@ -13,7 +13,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 ; stream that reads the input and chunks the data to the output
 

--- a/client.cl
+++ b/client.cl
@@ -20,7 +20,7 @@
 
 (in-package :net.aserve.client)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (net.aserve::check-smp-consistency)
 
@@ -802,10 +802,6 @@
   ;;  proxy is set to nil for this call)
   ;;
 
-  (declare (ignorable timeout certificate key certificate-password ca-file 
-		      ca-directory crl-file crl-check verify max-depth 
-                      ssl-method ssl-args))
-  
   
   (if* (and connection (not use-socket))
      then ; try using it

--- a/decode.cl
+++ b/decode.cl
@@ -14,7 +14,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 ;---------------- urlencoding ----------------
 ; there are two similar yet distinct encodings for character strings

--- a/examples/examples.cl
+++ b/examples/examples.cl
@@ -75,7 +75,7 @@
 			 (:b "bar2") ")"
 			 :br
 			 ((:a :href "local-secret") "Test source based authorization") " This will only work if you can use "
-			 "http:://localhost ... to reach this page" :
+			 "http://localhost ... to reach this page" :
 			 :br
 			 ((:a :href "local-secret-auth") 
 			  "Like the preceding but uses authorizer objects")

--- a/headers.cl
+++ b/headers.cl
@@ -15,7 +15,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (defvar *header-byte-array*
     ;; unsigned-byte 8 vector contains the characters referenced by
@@ -73,7 +73,7 @@
   ;; where in the buffer the 2byte entry for header 'index' is located
   `(- *header-block-size* 6  (ash ,index 1)))
 
-(eval-when (compile eval)
+(eval-when (:compile-toplevel :execute)
   ;; the headers from the http spec
   ;; Following the header name we specify how to 
   ;; 1.  transfer client  request headers and 
@@ -159,7 +159,7 @@
 
 
 
-(eval-when (compile eval)
+(eval-when (:compile-toplevel :execute)
   (defmacro build-header-lookup-table ()
     (let ((max-length 0)
 	  (total-length 0))
@@ -172,7 +172,7 @@
     
       (let ((header-byte-array (make-array total-length
 					   :element-type '(unsigned-byte 8)))
-	    (header-lookup-array (make-array (1+ max-length))))
+	    (header-lookup-array (make-array (1+ max-length) :initial-element nil)))
       
 	(let ((hba -1)
 	      (header-number -1)

--- a/htmlgen/htmlgen.cl
+++ b/htmlgen/htmlgen.cl
@@ -32,7 +32,7 @@
 
 (in-package :net.html.generator)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 ;; html generation
 

--- a/log.cl
+++ b/log.cl
@@ -15,7 +15,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (defun log1 (category level message &key (logger *logger*))
   (log1* logger category level message))

--- a/macs.cl
+++ b/macs.cl
@@ -21,7 +21,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 ;; add features based on the capabilities of the host lisp
 #+(version>= 6 1) (pushnew :io-timeout *features*) ; support i/o timeouts

--- a/main.cl
+++ b/main.cl
@@ -16,14 +16,14 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 #+ignore
 (check-smp-consistency)
 
 (defparameter *aserve-version* '(1 3 65))
 
-(eval-when (eval load)
+(eval-when (:execute :load-toplevel)
     (require :sock)
     (require :process)
     #+(version>= 6) (require :acldns) ; not strictly required but this is preferred
@@ -850,7 +850,7 @@ Problems with protocol may occur." (ef-name ef)))))
        
 
 
-(eval-when (compile load eval)
+(eval-when (:compile-toplevel :load-toplevel :execute)
   ;; these are the common headers and are stored in slots in 
   ;; the objects
   ;; the list consists of  ("name" . name)
@@ -1688,7 +1688,7 @@ by keyword symbols and not by strings"
 	     ;; 8.1.
 	     #+(version>= 8 1)
 	     ((member :zoom-on-error *debug-current* :test #'eq)
-	      (tagbody out
+	      (tagbody 
 		(handler-bind
 		    ((error
 		      (lambda (cond)
@@ -1713,7 +1713,7 @@ by keyword symbols and not by strings"
 				   then ; after the zoom ignore the error
 					(go out))
 				))))
-		  (process-connection sock))))
+		  (process-connection sock)) out))
 	     ((not (member :notrap *debug-current* :test #'eq))
 	      (handler-case (process-connection sock)
 		(error (cond)

--- a/packages.cl
+++ b/packages.cl
@@ -93,7 +93,7 @@ v1: 1.3.16: fix freeing freed buffer."
 ;
 (in-package :user)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (eval-when (compile load eval)
   (require :osi)
@@ -103,7 +103,7 @@ v1: 1.3.16: fix freeing freed buffer."
   (require :streamc)
   (require :inflate))
 
-(eval-when (compile load eval)
+(eval-when (:compile-toplevel :load-toplevel :execute)
   (defvar sys::*user-warned-about-deflate* nil)
   (handler-case (require :deflate)
     (error (c)

--- a/parse.cl
+++ b/parse.cl
@@ -18,7 +18,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (check-smp-consistency)
 

--- a/proxy.cl
+++ b/proxy.cl
@@ -15,7 +15,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (check-smp-consistency)
 

--- a/publish.cl
+++ b/publish.cl
@@ -14,7 +14,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 (defclass entity ()
   ;; an object to be published

--- a/queue.cl
+++ b/queue.cl
@@ -3,7 +3,7 @@
 
 (in-package :net.aserve)
 
-(eval-when (compile) (declaim (optimize (speed 3))))
+(eval-when (:compile-toplevel) (declaim (optimize (speed 3))))
 
 #+(version= 8 2)
 (eval-when (:compile-toplevel :load-toplevel :execute)


### PR DESCRIPTION
Minimized changes to what look like general ANSI compliance issues.  Will try to keep this branch in synch with this upstream (both ways). 

As suggested by @franzinc, will maintain gendl/aserve master branch as a slightly modified branch for portability-specific changes which aren't general aserve fixes (compliance or otherwise). 